### PR TITLE
Preserve effect annotations through C and WAT codegen

### DIFF
--- a/src/aria/codegen_c.clj
+++ b/src/aria/codegen_c.clj
@@ -277,10 +277,45 @@
   (emit-raw! cg (str "} " name ";"))
   (emit-raw! cg ""))
 
+(defn- has-ptr-param? [func]
+  (some #(= :ptr (:type/kind (:param/type %))) (:params func)))
+
+(defn- returns-ptr? [func]
+  (= :ptr (:type/kind (:result func))))
+
+(defn- effects->c-attr
+  "Map ARIA effect set to a C compiler attribute string, or nil."
+  [func]
+  (let [effs (set (:effects func))]
+    (cond
+      ;; pure + no pointer params = truly const (no memory reads)
+      (and (contains? effs :pure) (not (has-ptr-param? func)))
+      "__attribute__((const)) "
+
+      ;; pure + pointer params = reads memory but no side effects
+      (and (contains? effs :pure) (has-ptr-param? func))
+      "__attribute__((pure)) "
+
+      ;; mem + returns pointer = malloc-like
+      (and (contains? effs :mem) (returns-ptr? func))
+      "__attribute__((malloc)) "
+
+      :else nil)))
+
+(defn- effects->c-comment
+  "Emit an effects comment for non-attribute cases, or nil."
+  [func]
+  (when (seq (:effects func))
+    (let [effs (sort (map name (:effects func)))]
+      (str "/* effects: " (str/join " " effs) " */"))))
+
 (defn- gen-function! [cg func]
   ;; Intent as doc comment
   (when (:intent func)
     (emit-raw! cg (str "/* " (:intent func) " */")))
+  ;; Effects comment (always emitted when effects present)
+  (when-let [comment (effects->c-comment func)]
+    (emit-raw! cg comment))
   ;; Signature
   (let [ret-type (if (:result func) (type->c (:result func)) "void")
         params (if (seq (:params func))
@@ -290,8 +325,9 @@
                                        (var->c (:param/name p))))
                                 (:params func)))
                  "void")
-        fname (var->c (:name func))]
-    (emit-raw! cg (str ret-type " " fname "(" params ") {"))
+        fname (var->c (:name func))
+        attr (or (effects->c-attr func) "")]
+    (emit-raw! cg (str attr ret-type " " fname "(" params ") {"))
     (swap! (:indent cg) inc)
     ;; Body (locals are now let-bindings in body, handled by gen-stmt!)
     (doseq [node (:body func)]
@@ -333,8 +369,9 @@
                                            (var->c (:param/name p))))
                                     (:params func)))
                      "void")
-            fname (var->c (:name func))]
-        (emit-raw! cg (str ret-type " " fname "(" params ");"))))
+            fname (var->c (:name func))
+            attr (or (effects->c-attr func) "")]
+        (emit-raw! cg (str attr ret-type " " fname "(" params ");"))))
     (emit-raw! cg "")
 
     ;; Globals

--- a/src/aria/codegen_wat.clj
+++ b/src/aria/codegen_wat.clj
@@ -839,6 +839,10 @@
         param-names (set (map #(var->wat (:param/name %)) params))
         func-locals (into (sorted-map) (remove (fn [[k _]] (param-names k)) locals))]
 
+    ;; Effects as comment
+    (when (seq (:effects func))
+      (emit! cg (str ";; effects: " (str/join " " (sort (map name (:effects func)))))))
+
     ;; Intent as comment
     (when (:intent func)
       (emit! cg (str ";; " (:intent func))))

--- a/test/aria/codegen_c_test.clj
+++ b/test/aria/codegen_c_test.clj
@@ -1,0 +1,72 @@
+(ns aria.codegen-c-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [aria.parser :as parser]
+            [aria.codegen-c :as codegen-c]
+            [clojure.string :as str]))
+
+;; ── Helper ───────────────────────────────────────────────────
+
+(defn- gen-c [source]
+  (let [module (parser/parse source)]
+    (codegen-c/generate module)))
+
+;; ── Effect Annotation Tests ────────────────────────────────
+
+(deftest effects-const-attr-test
+  (testing "Pure function without ptr params gets __attribute__((const))"
+    (let [c (gen-c "(module \"t\"
+                      (func $fibonacci (param $n i32) (result i32)
+                        (effects pure)
+                        (return $n)))")]
+      (is (str/includes? c "__attribute__((const))"))
+      (is (str/includes? c "/* effects: pure */")))))
+
+(deftest effects-pure-attr-test
+  (testing "Pure function with ptr param gets __attribute__((pure))"
+    (let [c (gen-c "(module \"t\"
+                      (func $sum_array (param $arr (ptr i32)) (param $len i32) (result i32)
+                        (effects pure)
+                        (return $len)))")]
+      (is (str/includes? c "__attribute__((pure))"))
+      (is (not (str/includes? c "__attribute__((const))")))
+      (is (str/includes? c "/* effects: pure */")))))
+
+(deftest effects-malloc-attr-test
+  (testing "Mem function returning ptr gets __attribute__((malloc))"
+    (let [c (gen-c "(module \"t\"
+                      (func $alloc_buf (param $size i32) (result (ptr u8))
+                        (effects mem)
+                        (return (alloc (ptr u8) $size))))")]
+      (is (str/includes? c "__attribute__((malloc))"))
+      (is (str/includes? c "/* effects: mem */")))))
+
+(deftest effects-comment-only-test
+  (testing "IO effects get comment but no compiler attribute"
+    (let [c (gen-c "(module \"t\"
+                      (func $greet (effects io) (print \"hello\")))")]
+      (is (str/includes? c "/* effects: io */"))
+      (is (not (str/includes? c "__attribute__"))))))
+
+(deftest effects-multiple-test
+  (testing "Multiple effects are sorted in comment"
+    (let [c (gen-c "(module \"t\"
+                      (func $work (param $p (ptr i32)) (param $n i32)
+                        (effects io mem div)
+                        (print \"%d\" $n)))")]
+      (is (str/includes? c "/* effects: div io mem */")))))
+
+(deftest effects-forward-decl-test
+  (testing "Forward declarations also carry the attribute"
+    (let [c (gen-c "(module \"t\"
+                      (func $f (param $n i32) (result i32)
+                        (effects pure)
+                        (return $n)))")
+          lines (str/split-lines c)
+          fwd-decl (first (filter #(and (str/includes? % "fibonacci\\|;")
+                                        (str/ends-with? % ");"))
+                                  lines))
+          ;; Find forward declaration line (ends with ;)
+          fwd-lines (filter #(and (str/includes? % "__attribute__((const))")
+                                  (str/ends-with? (str/trim %) ");"))
+                            lines)]
+      (is (seq fwd-lines) "Forward declaration should have __attribute__((const))"))))

--- a/test/aria/codegen_wat_test.clj
+++ b/test/aria/codegen_wat_test.clj
@@ -236,3 +236,34 @@
       (is (str/includes? wat "(memory (export \"memory\") 1)"))
       ;; Should close properly
       (is (str/ends-with? (str/trim wat) ")")))))
+
+;; ── Effect Annotation Tests ────────────────────────────────
+
+(deftest effects-comment-test
+  (testing "Single effect emitted as WAT comment"
+    (let [wat (gen-wat "(module \"t\"
+                          (func $f (result i32) (effects pure) (return 42))
+                          (export $f))")]
+      (is (str/includes? wat ";; effects: pure"))))
+
+  (testing "Multiple effects emitted sorted"
+    (let [wat (gen-wat "(module \"t\"
+                          (func $f (param $arr (ptr i32)) (param $n i32)
+                            (effects io mem div)
+                            (intent \"test\")
+                            (print \"%d\" $n))
+                          (export $f))")]
+      (is (str/includes? wat ";; effects: div io mem"))))
+
+  (testing "Effects comment appears before intent comment"
+    (let [wat (gen-wat "(module \"t\"
+                          (func $f (result i32)
+                            (effects pure)
+                            (intent \"Compute something\")
+                            (return 1))
+                          (export $f))")
+          effects-idx (str/index-of wat ";; effects:")
+          intent-idx (str/index-of wat ";; Compute something")]
+      (is (some? effects-idx))
+      (is (some? intent-idx))
+      (is (< effects-idx intent-idx)))))


### PR DESCRIPTION
## Motivation

ARIA-IR functions declare effects (`pure`, `io`, `mem`, `div`) that the type checker verifies statically against the actual operations in the function body. However, both codegen backends (C and WAT) completely discarded this information during code generation. The effect annotations were verified and then lost — they did not survive into the compiled output.

This means that while the generated code was *functionally correct* (tests pass, output matches), there was no guarantee of *semantic fidelity* through the pipeline. A `mul.i32` declared with `(effects pure)` in ARIA-IR became a valid `i32.mul` in WASM or `int32_t` multiplication in C without the codegen ever consulting the effect metadata. As noted in the review of the previous PR: "Tests passing confirms output correctness. It does not confirm semantic fidelity through the pipeline."

This PR closes that gap by making effect annotations visible in the generated code of both backends, with each backend using the approach most appropriate to its target.

## Solution

### C Backend

C compilers (GCC/Clang) have `__attribute__` annotations that map directly to ARIA's effect semantics and enable **real compiler optimizations**:

| ARIA Effect | C Attribute | Optimization Impact |
|---|---|---|
| `pure` (no ptr params) | `__attribute__((const))` | CSE, dead call elimination, call reordering — the compiler can deduplicate identical calls |
| `pure` (with ptr params) | `__attribute__((pure))` | Same optimizations, but the function is allowed to read memory through its pointer arguments |
| `mem` (returns ptr) | `__attribute__((malloc))` | Returned pointer does not alias existing pointers — enables alias analysis optimizations |
| Other combinations | No attribute | Default C behavior |

Additionally, all functions with declared effects get a `/* effects: ... */` comment for human readability and auditability.

Attributes are emitted on both forward declarations and function definitions for consistency.

**Example output** (`fibonacci.aria`):
```c
__attribute__((const)) int32_t fibonacci(int32_t n);  // forward decl

/* Compute the nth Fibonacci number using recursion */
/* effects: pure */
__attribute__((const)) int32_t fibonacci(int32_t n) {
    ...
}
```

### WAT Backend

WASM has no native effect system, so the approach here is metadata preservation via comments. Each function emits a `;; effects: ...` comment before the function definition, placed before the existing intent comment for consistent metadata ordering.

```wat
;; effects: pure
;; Compute the nth Fibonacci number using recursion
(func $fibonacci (param $n i32) (result i32)
  ...
)
```

This preserves effect information for tooling, inspection, and potential future use in WASM custom sections.

## Test plan

- [x] All 76 existing tests pass (0 failures, 0 errors)
- [x] New `codegen_c_test.clj`: tests `__attribute__((const))`, `__attribute__((pure))`, `__attribute__((malloc))`, comment-only fallback, multiple effects sorting, forward declaration attributes
- [x] New tests in `codegen_wat_test.clj`: single effect comment, multiple effects sorted, effects comment ordering before intent
- [x] Manual verification: `fibonacci.aria` generates correct attributes in C and correct comments in WAT
- [x] Generated C compiles cleanly with `gcc -O2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)