### PR TITLE
ARIA-JVM Phase 1: JVM bytecode backend

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,7 @@
 {:paths ["src"]
  :deps  {org.clojure/clojure {:mvn/version "1.12.0"}
-         org.clojure/data.json {:mvn/version "2.5.1"}}
+         org.clojure/data.json {:mvn/version "2.5.1"}
+         org.ow2.asm/asm {:mvn/version "9.7.1"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps  {io.github.cognitect-labs/test-runner
@@ -10,4 +11,5 @@
          :exec-fn     cognitect.test-runner.api/test}
   :run  {:main-opts ["-m" "aria.main"]}
   :gen  {:main-opts ["-m" "aria.gen"]}
-  :wasm {:main-opts ["-m" "aria.main" "--backend" "wasm"]}}}
+  :wasm {:main-opts ["-m" "aria.main" "--backend" "wasm"]}
+  :jvm  {:main-opts ["-m" "aria.main" "--backend" "jvm"]}}}

--- a/src/aria/codegen_jvm.clj
+++ b/src/aria/codegen_jvm.clj
@@ -1,0 +1,452 @@
+(ns aria.codegen-jvm
+  "JVM bytecode backend for ARIA-IR.
+  Compiles a validated AST (post-checker) to a .class file using ASM.
+  Entry points: generate-class and emit-class-file!"
+  (:require [clojure.string :as str])
+  (:import [org.objectweb.asm ClassWriter MethodVisitor Opcodes Label]))
+
+;; ── Type Helpers ────────────────────────────────────────────
+
+(defn- aria-type->descriptor [t]
+  (case t
+    :i32  "I"
+    :i64  "J"
+    :f64  "D"
+    :bool "Z"
+    :str  "Ljava/lang/String;"
+    :void "V"
+    (throw (ex-info "Unknown ARIA type" {:type t}))))
+
+(defn- aria-type->load-op [t]
+  (case t
+    (:i32 :bool) Opcodes/ILOAD
+    :i64         Opcodes/LLOAD
+    :f64         Opcodes/DLOAD
+    :str         Opcodes/ALOAD
+    (throw (ex-info "No load opcode for type" {:type t}))))
+
+(defn- aria-type->store-op [t]
+  (case t
+    (:i32 :bool) Opcodes/ISTORE
+    :i64         Opcodes/LSTORE
+    :f64         Opcodes/DSTORE
+    :str         Opcodes/ASTORE
+    (throw (ex-info "No store opcode for type" {:type t}))))
+
+(defn- aria-type->return-op [t]
+  (case t
+    (:i32 :bool) Opcodes/IRETURN
+    :i64         Opcodes/LRETURN
+    :f64         Opcodes/DRETURN
+    :str         Opcodes/ARETURN
+    :void        Opcodes/RETURN
+    (throw (ex-info "No return opcode for type" {:type t}))))
+
+(defn- type-suffix->kw
+  "Convert ARIA type suffix string to keyword."
+  [s]
+  (keyword s))
+
+(defn- aria-type-map->kw
+  "Convert AST type map {:type/kind :primitive :type/name \"i32\"} to keyword."
+  [t]
+  (when t
+    (if (= :primitive (:type/kind t))
+      (keyword (:type/name t))
+      (throw (ex-info "Non-primitive type in JVM backend" {:type t})))))
+
+(defn- wide-type?
+  "Returns true for types that occupy two JVM slots (long, double)."
+  [t]
+  (contains? #{:i64 :f64} t))
+
+;; ── Arithmetic ──────────────────────────────────────────────
+
+(defn- emit-binop [^MethodVisitor mv {:keys [op type]}]
+  (case [op type]
+    [:add :i32] (.visitInsn mv Opcodes/IADD)
+    [:sub :i32] (.visitInsn mv Opcodes/ISUB)
+    [:mul :i32] (.visitInsn mv Opcodes/IMUL)
+    [:div :i32] (.visitInsn mv Opcodes/IDIV)
+    [:add :i64] (.visitInsn mv Opcodes/LADD)
+    [:sub :i64] (.visitInsn mv Opcodes/LSUB)
+    [:mul :i64] (.visitInsn mv Opcodes/LMUL)
+    [:div :i64] (.visitInsn mv Opcodes/LDIV)
+    [:add :f64] (.visitInsn mv Opcodes/DADD)
+    [:sub :f64] (.visitInsn mv Opcodes/DSUB)
+    [:mul :f64] (.visitInsn mv Opcodes/DMUL)
+    [:div :f64] (.visitInsn mv Opcodes/DDIV)
+    (throw (ex-info "Unknown binary op" {:op op :type type}))))
+
+;; ── Comparison ──────────────────────────────────────────────
+
+(defn- emit-i32-comparison
+  "Emit an i32 comparison that leaves 0 or 1 on the stack."
+  [^MethodVisitor mv op]
+  (let [true-label (Label.)
+        end-label (Label.)
+        if-op (case op
+                "eq" Opcodes/IF_ICMPEQ
+                "ne" Opcodes/IF_ICMPNE
+                "lt" Opcodes/IF_ICMPLT
+                "le" Opcodes/IF_ICMPLE
+                "gt" Opcodes/IF_ICMPGT
+                "ge" Opcodes/IF_ICMPGE)]
+    (.visitJumpInsn mv if-op true-label)
+    (.visitInsn mv Opcodes/ICONST_0)
+    (.visitJumpInsn mv Opcodes/GOTO end-label)
+    (.visitLabel mv true-label)
+    (.visitInsn mv Opcodes/ICONST_1)
+    (.visitLabel mv end-label)))
+
+;; ── Var name helpers ────────────────────────────────────────
+
+(defn- clean-name
+  "Strip $ or % prefix from ARIA var name."
+  [name]
+  (cond
+    (str/starts-with? name "$") (subs name 1)
+    (str/starts-with? name "%") (subs name 1)
+    :else name))
+
+;; ── Code generation context ─────────────────────────────────
+
+(defn- make-ctx
+  "Create a code generation context for a method."
+  [class-name functions]
+  {:class-name class-name
+   :functions functions        ; map of func-name -> func AST
+   :locals (atom {})           ; var-name -> {:slot int :type keyword}
+   :next-slot (atom 0)
+   :loop-labels (atom {})})    ; loop-label -> Label (start of loop)
+
+(defn- alloc-local!
+  "Allocate a local variable slot. Wide types (i64/f64) take 2 slots."
+  [ctx var-name type-kw]
+  (let [slot @(:next-slot ctx)]
+    (swap! (:locals ctx) assoc var-name {:slot slot :type type-kw})
+    (swap! (:next-slot ctx) + (if (wide-type? type-kw) 2 1))
+    slot))
+
+(defn- get-local [ctx var-name]
+  (get @(:locals ctx) var-name))
+
+;; ── Expression Codegen ──────────────────────────────────────
+
+(declare emit-expr!)
+(declare emit-stmt!)
+(declare emit-print!)
+
+(defn- emit-expr!
+  "Emit bytecode that pushes the expression's value onto the stack."
+  [^MethodVisitor mv ctx node]
+  (case (:node/type node)
+    :int-literal
+    (let [v (long (:value node))]
+      (cond
+        (<= -1 v 5)    (.visitInsn mv (+ Opcodes/ICONST_0 (int v)))
+        (<= -128 v 127) (.visitIntInsn mv Opcodes/BIPUSH (int v))
+        (<= -32768 v 32767) (.visitIntInsn mv Opcodes/SIPUSH (int v))
+        :else           (.visitLdcInsn mv (int v))))
+
+    :float-literal
+    (.visitLdcInsn mv (double (:value node)))
+
+    :bool-literal
+    (if (:value node)
+      (.visitInsn mv Opcodes/ICONST_1)
+      (.visitInsn mv Opcodes/ICONST_0))
+
+    :string-literal
+    (.visitLdcInsn mv (:value node))
+
+    :var-ref
+    (let [var-name (:name node)
+          local (get-local ctx var-name)]
+      (when-not local
+        (throw (ex-info "Undefined variable in JVM codegen" {:name var-name})))
+      (.visitVarInsn mv (aria-type->load-op (:type local)) (:slot local)))
+
+    :bin-op
+    (let [type-kw (type-suffix->kw (:type-suffix node))]
+      (emit-expr! mv ctx (:left node))
+      (emit-expr! mv ctx (:right node))
+      (emit-binop mv {:op (keyword (:op node)) :type type-kw}))
+
+    :comparison
+    (let [type-kw (type-suffix->kw (:type-suffix node))]
+      (emit-expr! mv ctx (:left node))
+      (emit-expr! mv ctx (:right node))
+      (case type-kw
+        :i32 (emit-i32-comparison mv (:op node))))
+
+    :call
+    (let [target (:target node)
+          func (get (:functions ctx) target)]
+      (when-not func
+        (throw (ex-info "Undefined function in JVM codegen" {:target target})))
+      ;; Push arguments
+      (doseq [arg (:args node)]
+        (emit-expr! mv ctx arg))
+      ;; Build descriptor
+      (let [param-descs (str/join ""
+                          (map (fn [p] (aria-type->descriptor
+                                        (aria-type-map->kw (:param/type p))))
+                               (:params func)))
+            ret-desc (if (:result func)
+                       (aria-type->descriptor (aria-type-map->kw (:result func)))
+                       "V")
+            desc (str "(" param-descs ")" ret-desc)]
+        (.visitMethodInsn mv Opcodes/INVOKESTATIC
+                          (:class-name ctx)
+                          (clean-name target)
+                          desc
+                          false)))
+
+    ;; If used as expression (single then/else producing a value)
+    :if
+    (let [else-label (Label.)
+          end-label (Label.)]
+      ;; Emit condition
+      (emit-expr! mv ctx (:cond node))
+      ;; Branch if false (0)
+      (.visitJumpInsn mv Opcodes/IFEQ else-label)
+      ;; Then body
+      (doseq [n (butlast (:then-body node))]
+        (emit-stmt! mv ctx n))
+      (when (seq (:then-body node))
+        (let [last-node (last (:then-body node))]
+          (if (= :return (:node/type last-node))
+            (emit-stmt! mv ctx last-node)
+            (emit-expr! mv ctx last-node))))
+      (.visitJumpInsn mv Opcodes/GOTO end-label)
+      ;; Else body
+      (.visitLabel mv else-label)
+      (when (seq (:else-body node))
+        (doseq [n (butlast (:else-body node))]
+          (emit-stmt! mv ctx n))
+        (let [last-node (last (:else-body node))]
+          (if (= :return (:node/type last-node))
+            (emit-stmt! mv ctx last-node)
+            (emit-expr! mv ctx last-node))))
+      (.visitLabel mv end-label))
+
+    (throw (ex-info "Unknown expression node in JVM codegen" {:node/type (:node/type node)}))))
+
+;; ── Statement Codegen ───────────────────────────────────────
+
+(defn- emit-stmt!
+  "Emit bytecode for a statement node."
+  [^MethodVisitor mv ctx node]
+  (case (:node/type node)
+    :intent nil ;; Intent annotations are no-ops in Phase 1
+
+    :let
+    (let [type-kw (aria-type-map->kw (:aria/type node))
+          slot (alloc-local! ctx (:name node) type-kw)]
+      (emit-expr! mv ctx (:value node))
+      (.visitVarInsn mv (aria-type->store-op type-kw) slot))
+
+    :set-var
+    (let [var-name (:name node)
+          local (get-local ctx var-name)]
+      (when-not local
+        (throw (ex-info "Undefined variable in set-var" {:name var-name})))
+      (emit-expr! mv ctx (:value node))
+      (.visitVarInsn mv (aria-type->store-op (:type local)) (:slot local)))
+
+    :return
+    (if (:value node)
+      (do (emit-expr! mv ctx (:value node))
+          (let [ret-type (or (:return-type (meta ctx)) :i32)]
+            (.visitInsn mv (aria-type->return-op ret-type))))
+      (.visitInsn mv Opcodes/RETURN))
+
+    :if
+    (let [else-label (Label.)
+          end-label (Label.)]
+      (emit-expr! mv ctx (:cond node))
+      (.visitJumpInsn mv Opcodes/IFEQ else-label)
+      (doseq [n (:then-body node)]
+        (emit-stmt! mv ctx n))
+      (.visitJumpInsn mv Opcodes/GOTO end-label)
+      (.visitLabel mv else-label)
+      (doseq [n (:else-body node)]
+        (emit-stmt! mv ctx n))
+      (.visitLabel mv end-label))
+
+    :loop
+    (let [start-label (Label.)
+          end-label (Label.)]
+      (when (seq (:label node))
+        (swap! (:loop-labels ctx) assoc (:label node) {:start start-label :end end-label}))
+      (.visitLabel mv start-label)
+      (doseq [n (:body node)]
+        (emit-stmt! mv ctx n))
+      (.visitJumpInsn mv Opcodes/GOTO start-label)
+      (.visitLabel mv end-label))
+
+    :branch
+    (if (nil? (:cond node))
+      ;; Unconditional break
+      (let [labels (get @(:loop-labels ctx) (:label node))]
+        (.visitJumpInsn mv Opcodes/GOTO (:end labels)))
+      ;; Conditional break
+      (let [labels (get @(:loop-labels ctx) (:label node))]
+        (emit-expr! mv ctx (:cond node))
+        (.visitJumpInsn mv Opcodes/IFNE (:end labels))))
+
+    :print
+    (emit-print! mv ctx node)
+
+    :call
+    (do (emit-expr! mv ctx node)
+        ;; Pop return value if the call is used as a statement
+        (let [func (get (:functions ctx) (:target node))]
+          (when (and func (:result func))
+            (let [type-kw (aria-type-map->kw (:result func))]
+              (if (wide-type? type-kw)
+                (.visitInsn mv Opcodes/POP2)
+                (.visitInsn mv Opcodes/POP))))))
+
+    :seq
+    (doseq [n (:body node)]
+      (emit-stmt! mv ctx n))
+
+    ;; Default: try as expression statement
+    (emit-expr! mv ctx node)))
+
+;; ── Print codegen ───────────────────────────────────────────
+
+(defn- emit-print!
+  "Emit bytecode for a print statement using System.out.printf."
+  [^MethodVisitor mv ctx node]
+  (let [fmt (:format-str node)
+        args (:args node)]
+    ;; Get System.out
+    (.visitFieldInsn mv Opcodes/GETSTATIC "java/lang/System" "out" "Ljava/io/PrintStream;")
+    ;; Push format string
+    (.visitLdcInsn mv fmt)
+    ;; Create Object[] for varargs
+    (.visitLdcInsn mv (int (count args)))
+    (.visitTypeInsn mv Opcodes/ANEWARRAY "java/lang/Object")
+    ;; Fill array
+    (doseq [[i arg] (map-indexed vector args)]
+      (.visitInsn mv Opcodes/DUP)
+      (.visitLdcInsn mv (int i))
+      (emit-expr! mv ctx arg)
+      ;; Box primitive
+      (.visitMethodInsn mv Opcodes/INVOKESTATIC
+                        "java/lang/Integer" "valueOf"
+                        "(I)Ljava/lang/Integer;" false)
+      (.visitInsn mv Opcodes/AASTORE))
+    ;; Call printf
+    (.visitMethodInsn mv Opcodes/INVOKEVIRTUAL
+                      "java/io/PrintStream" "printf"
+                      "(Ljava/lang/String;[Ljava/lang/Object;)Ljava/io/PrintStream;"
+                      false)
+    ;; Pop the returned PrintStream
+    (.visitInsn mv Opcodes/POP)))
+
+;; ── Method Codegen ──────────────────────────────────────────
+
+(defn- emit-method!
+  "Emit a single ARIA function as a static JVM method."
+  [^ClassWriter cw class-name functions func]
+  (let [fname (clean-name (:name func))
+        params (:params func)
+        result (:result func)
+        param-descs (str/join ""
+                      (map (fn [p] (aria-type->descriptor
+                                    (aria-type-map->kw (:param/type p))))
+                           params))
+        ret-kw (if result (aria-type-map->kw result) :void)
+        ret-desc (aria-type->descriptor ret-kw)
+        desc (str "(" param-descs ")" ret-desc)
+        access (+ Opcodes/ACC_PUBLIC Opcodes/ACC_STATIC)
+        mv (.visitMethod cw access fname desc nil nil)
+        ctx (make-ctx class-name functions)]
+    ;; Store return type in ctx for use by return statements
+    ;; We use a simple atom approach since meta on map doesn't work well with atoms
+    (.visitCode mv)
+    ;; Allocate parameter slots
+    (doseq [p params]
+      (let [type-kw (aria-type-map->kw (:param/type p))
+            pname (:param/name p)]
+        (alloc-local! ctx pname type-kw)))
+    ;; Emit body statements
+    (doseq [node (:body func)]
+      (emit-stmt! mv (with-meta ctx {:return-type ret-kw}) node))
+    ;; Add a safety return in case body doesn't end with return
+    (when (= ret-kw :void)
+      (.visitInsn mv Opcodes/RETURN))
+    ;; Let ASM compute the max stack/locals
+    (.visitMaxs mv 0 0)
+    (.visitEnd mv)))
+
+;; ── Main method (entry point) ───────────────────────────────
+
+(defn- emit-main-wrapper!
+  "Emit a JVM main(String[]) that calls the ARIA $main function."
+  [^ClassWriter cw class-name functions main-func]
+  (let [mv (.visitMethod cw
+                         (+ Opcodes/ACC_PUBLIC Opcodes/ACC_STATIC)
+                         "main"
+                         "([Ljava/lang/String;)V"
+                         nil nil)]
+    (.visitCode mv)
+    ;; Call the ARIA main function
+    (let [result (:result main-func)
+          ret-kw (if result (aria-type-map->kw result) :void)
+          ret-desc (aria-type->descriptor ret-kw)]
+      (.visitMethodInsn mv Opcodes/INVOKESTATIC
+                        class-name "main"
+                        (str "()" ret-desc) false)
+      ;; Discard return value if any
+      (when (not= ret-kw :void)
+        (if (wide-type? ret-kw)
+          (.visitInsn mv Opcodes/POP2)
+          (.visitInsn mv Opcodes/POP))))
+    (.visitInsn mv Opcodes/RETURN)
+    (.visitMaxs mv 0 0)
+    (.visitEnd mv)))
+
+;; ── Public API ──────────────────────────────────────────────
+
+(defn generate-class
+  "Compiles a validated ARIA-IR AST to JVM bytecode.
+  Returns a byte array containing a valid .class file.
+  class-name must be a valid JVM binary name (e.g. \"Fibonacci\").
+  The AST must have passed aria.checker/check before calling this."
+  [ast class-name]
+  (let [cw (ClassWriter. ClassWriter/COMPUTE_FRAMES)
+        functions (into {} (map (fn [f] [(:name f) f]) (:functions ast)))]
+    (.visit cw
+            Opcodes/V11
+            (+ Opcodes/ACC_PUBLIC Opcodes/ACC_SUPER)
+            class-name nil "java/lang/Object" nil)
+    ;; Emit all functions as static methods
+    (doseq [func (:functions ast)]
+      (emit-method! cw class-name functions func))
+    ;; If there's a $main function, emit a JVM main(String[]) wrapper
+    (when-let [main-func (get functions "$main")]
+      (emit-main-wrapper! cw class-name functions main-func))
+    (.visitEnd cw)
+    (.toByteArray cw)))
+
+(defn emit-class-file!
+  "Writes a compiled .class file to output-dir.
+  Creates output-dir if it does not exist.
+  Returns the java.io.File written."
+  [ast output-dir]
+  (let [module-name (:name ast)
+        class-name (str (Character/toUpperCase (first module-name))
+                        (subs module-name 1))
+        bytes (generate-class ast class-name)
+        dir (java.io.File. output-dir)
+        out-file (java.io.File. dir (str class-name ".class"))]
+    (.mkdirs dir)
+    (with-open [os (java.io.FileOutputStream. out-file)]
+      (.write os ^bytes bytes))
+    (println (str "Wrote " (.getPath out-file) " (" (count bytes) " bytes)"))
+    out-file))

--- a/src/aria/main.clj
+++ b/src/aria/main.clj
@@ -15,6 +15,7 @@
             [aria.checker :as checker]
             [aria.codegen-c :as codegen-c]
             [aria.codegen-wat :as codegen-wat]
+            [aria.codegen-jvm :as codegen-jvm]
             [aria.reader :as reader]
             [clojure.pprint :as pp]
             [clojure.string :as str])
@@ -354,6 +355,10 @@
           :else
           (println wat-source)))
 
+      ;; JVM backend
+      (= backend "jvm")
+      (codegen-jvm/emit-class-file! module ".")
+
       ;; C backend (default)
       :else
       (let [c-source (codegen-c/generate module)]
@@ -389,9 +394,10 @@
       opts
       (let [arg (first args)]
         (cond
-          (= arg "--emit-c")   (recur (rest args) (assoc opts :emit-c true))
-          (= arg "--emit-wat") (recur (rest args) (assoc opts :emit-wat true))
-          (= arg "--emit-ast") (recur (rest args) (assoc opts :emit-ast true))
+          (= arg "--emit-c")     (recur (rest args) (assoc opts :emit-c true))
+          (= arg "--emit-wat")   (recur (rest args) (assoc opts :emit-wat true))
+          (= arg "--emit-class") (recur (rest args) (assoc opts :backend "jvm"))
+          (= arg "--emit-ast")   (recur (rest args) (assoc opts :emit-ast true))
           (= arg "--check")    (recur (rest args) (assoc opts :check-only true))
           (= arg "--run")      (recur (rest args) (assoc opts :run true))
           (= arg "--optimize") (recur (rest args) (assoc opts :optimize true))

--- a/test/aria/codegen_jvm_test.clj
+++ b/test/aria/codegen_jvm_test.clj
@@ -1,0 +1,103 @@
+(ns aria.codegen-jvm-test
+  (:require [clojure.test :refer [deftest is are testing]]
+            [aria.ast :as ast]
+            [aria.codegen-jvm :as codegen-jvm]))
+
+;; ── Test Group 1: Type descriptor mapping ───────────────────
+
+(deftest type-descriptor-mapping
+  (are [type expected] (= expected (#'aria.codegen-jvm/aria-type->descriptor type))
+    :i32  "I"
+    :i64  "J"
+    :f64  "D"
+    :bool "Z"
+    :str  "Ljava/lang/String;"
+    :void "V"))
+
+(deftest unknown-type-throws
+  (is (thrown? clojure.lang.ExceptionInfo
+               (#'aria.codegen-jvm/aria-type->descriptor :unknown))))
+
+;; ── AST Fixtures ────────────────────────────────────────────
+
+(defn- minimal-ast-fixture
+  "Simplest valid ARIA program: a module with $main returning 0."
+  []
+  (ast/module "test" [] []
+    [(ast/function "$main"
+       []
+       (ast/primitive "i32")
+       #{:io}
+       nil
+       [(ast/return-node (ast/int-literal 0))])]
+    [(ast/export-node "$main" nil)]))
+
+(defn- add-i32-fixture
+  "A function that adds two i32 arguments."
+  [a b]
+  (ast/module "addtest" [] []
+    [(ast/function "$add"
+       [(ast/param "$a" (ast/primitive "i32"))
+        (ast/param "$b" (ast/primitive "i32"))]
+       (ast/primitive "i32")
+       #{:pure}
+       nil
+       [(ast/return-node
+          (ast/bin-op "add" "i32"
+            (ast/var-ref "$a")
+            (ast/var-ref "$b")))])]
+    [(ast/export-node "$add" nil)]))
+
+;; ── Test Group 2: Valid class file ──────────────────────────
+
+(deftest generates-valid-class-magic-bytes
+  (let [bytes (codegen-jvm/generate-class (minimal-ast-fixture) "TestClass")]
+    (is (= (int 0xCA) (bit-and (aget bytes 0) 0xFF)))
+    (is (= (int 0xFE) (bit-and (aget bytes 1) 0xFF)))
+    (is (= (int 0xBA) (bit-and (aget bytes 2) 0xFF)))
+    (is (= (int 0xBE) (bit-and (aget bytes 3) 0xFF)))))
+
+(deftest generates-non-empty-class
+  (let [bytes (codegen-jvm/generate-class (minimal-ast-fixture) "TestClass")]
+    (is (pos? (count bytes)))))
+
+;; ── Test Group 3: Round-trip execution ──────────────────────
+
+(defn- primitive-class
+  "Map boxed Class to primitive Class for reflection."
+  [^Class c]
+  (condp = c
+    Integer   Integer/TYPE
+    Long      Long/TYPE
+    Double    Double/TYPE
+    Boolean   Boolean/TYPE
+    c))
+
+(defn- load-and-invoke [class-bytes class-name method-name & args]
+  (let [tmp-dir (java.io.File/createTempFile "aria-jvm-test" "")
+        _ (.delete tmp-dir)
+        _ (.mkdirs tmp-dir)
+        class-file (java.io.File. tmp-dir (str class-name ".class"))
+        _ (with-open [os (java.io.FileOutputStream. class-file)]
+            (.write os ^bytes class-bytes))
+        loader (java.net.URLClassLoader. (into-array java.net.URL [(.toURL (.toURI tmp-dir))]))
+        klass  (.loadClass loader class-name)
+        param-types (into-array Class (map (comp primitive-class type) args))
+        method (.getMethod klass method-name param-types)
+        result (.invoke method nil (into-array Object args))]
+    (.close loader)
+    (.delete class-file)
+    (.delete tmp-dir)
+    result))
+
+(deftest add-i32-round-trip
+  (let [ast    (add-i32-fixture 3 4)
+        bytes  (codegen-jvm/generate-class ast "AddTest")
+        result (load-and-invoke bytes "AddTest" "add" (int 3) (int 4))]
+    (is (= 7 result))))
+
+(deftest main-returns-zero
+  (testing "minimal main function returns 0"
+    (let [bytes  (codegen-jvm/generate-class (minimal-ast-fixture) "MainTest")
+          result (load-and-invoke bytes "MainTest" "main")]
+      (is (= 0 result)))))


### PR DESCRIPTION
Implements Phase 1 of the JVM bytecode backend as specified in PLAN-jvm-backend.md.

Addresses #9

## What this does

Adds `aria.codegen-jvm`, a new backend parallel to `aria.codegen-c` and the
WAT backend. The `--backend jvm` flag routes to it. Output is a `.class` file
runnable directly on the JVM.

Acceptance test passes:

    clojure -M:run examples/fibonacci.aria --backend jvm --emit-class
    java Fibonacci

No gcc in the chain.

## Changes

- `deps.edn` -- adds `org.ow2.asm/asm 9.7.1` and `:jvm` alias
- `src/aria/codegen_jvm.clj` -- new JVM bytecode backend using ASM
- `src/aria/main.clj` -- routes `--backend jvm` to `codegen-jvm/emit-class-file!`
- `test/aria/codegen_jvm_test.clj` -- type mapping tests, magic byte
  validation, round-trip execution

## Test results

    Ran 82 tests containing 231 assertions.
    0 failures, 0 errors.

## Known limitations (Phase 2 and 3, tracked in #9)

- Pointer types not supported (`bubble_sort.aria` fails with "Non-primitive
  type in JVM backend")
- Some binary ops not yet implemented (`math_demo.aria` fails with "Unknown
  binary op")
- `--emit-jar` not yet implemented
- `@Intent` annotation pass not yet implemented

## Pre-existing issue (separate from this PR)

`fibonacci.aria` triggers a checker warning: `Function $main has undeclared
effect 'div'`. This predates this PR and is unrelated to the JVM backend.