### PR TITLE
Layer 4: intent verification engine (closes #6)

### DIFF
--- a/src/aria/verifier.clj
+++ b/src/aria/verifier.clj
@@ -5,11 +5,16 @@
   Requires ANTHROPIC_API_KEY environment variable.
   Entry points: verify, format-report"
   (:require [clojure.string :as str]
-            [clojure.data.json :as json])
+            [clojure.data.json :as json]
+            [aria.parser :as parser]
+            [aria.checker :as checker]
+            [aria.codegen-c :as codegen-c])
   (:import [java.net URI]
            [java.net.http HttpClient HttpRequest
                           HttpRequest$BodyPublishers
-                          HttpResponse$BodyHandlers]))
+                          HttpResponse$BodyHandlers]
+           [java.io File]
+           [java.lang ProcessBuilder]))
 
 ;; ── Intent extraction ────────────────────────────────────────
 
@@ -164,9 +169,9 @@
 
 (defn- call-api
   "Call the Anthropic Messages API for intent verification."
-  [api-key user-message model]
+  [api-key user-message model max-tokens]
   (let [body (json/write-str {"model"      model
-                              "max_tokens" 256
+                              "max_tokens" max-tokens
                               "messages"   [{"role" "user" "content" user-message}]})
         request (-> (HttpRequest/newBuilder)
                     (.uri (URI/create "https://api.anthropic.com/v1/messages"))
@@ -186,11 +191,208 @@
           content (get resp "content")]
       (get (first content) "text"))))
 
-;; ── Single function verification ─────────────────────────────
+(defn- parse-verdict
+  "Parse a VERIFIED/NOT_VERIFIED response into a result map."
+  [response func-name intent]
+  (let [lines (->> (str/split-lines response)
+                   (remove str/blank?))
+        verdict (str/trim (first lines))
+        explanation (str/trim (or (second lines) "No explanation provided."))]
+    {:function func-name
+     :intent intent
+     :verified? (= verdict "VERIFIED")
+     :explanation explanation}))
 
-(defn- verify-function
-  "Call the Claude API to verify one function's intent annotation.
-  Returns {:function name :intent str :verified? bool :explanation str}."
+;; ── Dynamic verification helpers ─────────────────────────────
+
+(defn- primitive-type?
+  "Returns true if the type is a primitive scalar (i32, i64, f64, bool, str)."
+  [t]
+  (and (= :primitive (:type/kind t))
+       (#{"i32" "i64" "f64" "bool" "str"} (:type/name t))))
+
+(defn- all-primitive-params?
+  "Returns true if all function params are primitive scalar types."
+  [func]
+  (every? #(primitive-type? (:param/type %)) (:params func)))
+
+(defn- print-format-for-type
+  "Returns the printf format specifier for a primitive type."
+  [type-name]
+  (case type-name
+    "i32"  "%d"
+    "i64"  "%ld"
+    "f64"  "%.6f"
+    "bool" "%d"
+    "str"  "%s"
+    "%d"))
+
+(defn- test-value-nodes
+  "Returns a vector of 3 AST literal nodes appropriate for a primitive type."
+  [type-name]
+  (case type-name
+    ("i32" "i64") [{:node/type :int-literal :value 0}
+                   {:node/type :int-literal :value 1}
+                   {:node/type :int-literal :value 5}]
+    ("f32" "f64") [{:node/type :float-literal :value 0.0}
+                   {:node/type :float-literal :value 1.0}
+                   {:node/type :float-literal :value 2.5}]
+    "bool"        [{:node/type :bool-literal :value false}
+                   {:node/type :bool-literal :value true}
+                   {:node/type :bool-literal :value false}]
+    [{:node/type :int-literal :value 0}
+     {:node/type :int-literal :value 1}
+     {:node/type :int-literal :value 2}]))
+
+(defn- test-value-strs
+  "Returns a vector of 3 string representations of test values."
+  [type-name]
+  (case type-name
+    ("i32" "i64") ["0" "1" "5"]
+    ("f32" "f64") ["0.0" "1.0" "2.5"]
+    "bool"        ["false" "true" "false"]
+    ["0" "1" "2"]))
+
+(defn- generate-wrapper-module
+  "Generate a wrapper module AST that calls func with test inputs and
+  prints the results. Embeds all original module functions.
+  Only call this for functions where all-primitive-params? is true."
+  [func module]
+  (let [target-name (:name func)
+        clean-name (-> target-name (str/replace #"^\$" ""))
+        module-name (str "aria_verify_" (str/replace clean-name "-" "_"))
+        params (:params func)
+        result (:result func)
+        has-printable-result? (and result
+                                   (= :primitive (:type/kind result))
+                                   (not= "void" (:type/name result)))
+        ;; Handle $main naming conflict
+        is-main? (= target-name "$main")
+        call-target (if is-main? "$aria_target" target-name)
+        ;; Prepare original functions:
+        ;; - If verifying $main: rename it to $aria_target
+        ;; - Otherwise: remove original $main (our wrapper takes its place)
+        orig-funcs (if is-main?
+                     (mapv (fn [f]
+                             (if (= (:name f) "$main")
+                               (assoc f :name "$aria_target")
+                               f))
+                           (:functions module))
+                     (filterv #(not= (:name %) "$main") (:functions module)))
+        ;; Build wrapper body
+        body (if (empty? params)
+               ;; No params: call once
+               (let [call {:node/type :call :target call-target :args []}]
+                 (if has-printable-result?
+                   [{:node/type :print
+                     :format-str (str clean-name "()=" (print-format-for-type (:type/name result)) "\n")
+                     :args [call]}
+                    {:node/type :return :value {:node/type :int-literal :value 0}}]
+                   [call
+                    {:node/type :return :value {:node/type :int-literal :value 0}}]))
+               ;; Has params: 3 test runs
+               (let [val-nodes (mapv #(test-value-nodes (:type/name (:param/type %))) params)
+                     val-strs (mapv #(test-value-strs (:type/name (:param/type %))) params)]
+                 (vec (concat
+                        (for [i (range 3)]
+                          (let [args (mapv #(nth % i) val-nodes)
+                                arg-strs (mapv #(nth % i) val-strs)
+                                call {:node/type :call :target call-target :args args}]
+                            (if has-printable-result?
+                              {:node/type :print
+                               :format-str (str clean-name "(" (str/join ", " arg-strs) ")="
+                                                (print-format-for-type (:type/name result)) "\n")
+                               :args [call]}
+                              call)))
+                        [{:node/type :return :value {:node/type :int-literal :value 0}}]))))
+        wrapper {:node/type :function
+                 :name "$main"
+                 :params []
+                 :result {:type/kind :primitive :type/name "i32"}
+                 :effects #{:io :mem :div}
+                 :intent "Verification wrapper"
+                 :body body}]
+    {:node/type :module
+     :name module-name
+     :types (or (:types module) [])
+     :globals (or (:globals module) [])
+     :functions (conj orig-funcs wrapper)
+     :exports [{:node/type :export :name "$main" :alias nil}]
+     :externs (or (:externs module) [])}))
+
+;; ── Compile and run ──────────────────────────────────────────
+
+(defn- compile-and-run!
+  "Compile a checked ARIA module to C, compile with gcc, run, and
+  capture stdout. Returns {:ok? bool :stdout str :error str-or-nil}.
+  Cleans up all temp files on exit."
+  [module]
+  (let [c-source (codegen-c/generate module)
+        tmp-name (str "aria_verify_" (:name module))
+        tmp-c    (str "/tmp/" tmp-name ".c")
+        tmp-bin  (str "/tmp/" tmp-name)]
+    (try
+      (spit tmp-c c-source)
+      (let [gcc-proc (.start (ProcessBuilder.
+                               ["gcc" "-std=c99" "-Wall" "-o"
+                                tmp-bin tmp-c "-lm"]))
+            _ (.waitFor gcc-proc)]
+        (if-not (zero? (.exitValue gcc-proc))
+          {:ok? false :stdout ""
+           :error (slurp (.getErrorStream gcc-proc))}
+          (let [run-proc (.start (ProcessBuilder. [tmp-bin]))
+                stdout   (slurp (.getInputStream run-proc))
+                _        (.waitFor run-proc)]
+            {:ok? true :stdout stdout :error nil})))
+      (finally
+        (.delete (File. tmp-c))
+        (.delete (File. tmp-bin))))))
+
+;; ── Dynamic verification ─────────────────────────────────────
+
+(defn- dynamic-verify-function
+  "Verify a function by compiling and running it with test inputs,
+  then asking Claude whether the observed output matches the intent.
+  Returns {:function str :intent str :verified? bool :explanation str}."
+  [func module api-key model]
+  (let [func-name (:name func)
+        intent (extract-intent func)]
+    (try
+      (let [wrapper-module (generate-wrapper-module func module)
+            check-result (checker/check wrapper-module)]
+        (if-not (:ok? check-result)
+          {:function func-name :intent intent :verified? false
+           :explanation (str "Wrapper generation failed: "
+                             (str/join "; " (:errors check-result)))}
+          (let [run-result (compile-and-run! wrapper-module)]
+            (if-not (:ok? run-result)
+              {:function func-name :intent intent :verified? false
+               :explanation (str "Compilation failed: " (:error run-result))}
+              (let [prompt (str "You are verifying that a function's observed behavior matches "
+                                "its declared intent.\n\n"
+                                "Function: " func-name "\n"
+                                "Declared intent: \"" intent "\"\n"
+                                "Observed behavior:\n" (:stdout run-result) "\n"
+                                "Does the observed output show correct results consistent with "
+                                "the declared intent? Focus on whether the function produces the "
+                                "right values — ignore implementation details like algorithm "
+                                "choice, performance characteristics, or method names.\n"
+                                "Respond with exactly two lines:\n"
+                                "Line 1: VERIFIED or NOT_VERIFIED\n"
+                                "Line 2: One sentence explaining why.")
+                    response (call-api api-key prompt model 256)]
+                (parse-verdict response func-name intent))))))
+      (catch Exception e
+        {:function func-name :intent intent :verified? false
+         :explanation (str "Verification unavailable: " (.getMessage e))}))))
+
+;; ── Static verification (fallback for complex params) ────────
+
+(defn- static-verify-function
+  "Verify a function by asking Claude to read the ARIA-IR code.
+  Used as fallback when dynamic verification is not possible
+  (e.g., pointer/complex params).
+  Returns {:function str :intent str :verified? bool :explanation str}."
   [func api-key model]
   (let [func-name (:name func)
         intent (extract-intent func)
@@ -199,36 +401,27 @@
                     "Function: " func-name "\n"
                     "Declared intent: \"" intent "\"\n\n"
                     "Implementation:\n" aria-str "\n\n"
-                    "ARIA-IR semantics:\n"
-                    "- (br $label) exits the named loop — break, not continue\n"
-                    "- (loop $label body...) repeats until (br $label) is reached\n"
-                    "- The pattern (loop $L (if EXIT (then (br $L)) (else BODY)))\n"
-                    "  means: run BODY while EXIT is false, stop when EXIT is true\n\n"
-                    "To verify this function:\n"
-                    "1. Choose one or two simple concrete inputs appropriate for\n"
-                    "   the declared intent\n"
-                    "2. Trace through the implementation step by step with those inputs\n"
-                    "3. State the result of your trace\n"
-                    "4. Compare the traced result to what the intent says should happen\n\n"
+                    "Does this implementation match the declared intent?\n"
                     "Respond with exactly two lines:\n"
                     "Line 1: VERIFIED or NOT_VERIFIED\n"
-                    "Line 2: One sentence summarizing your trace result and whether\n"
-                    "        it matches the intent.")]
+                    "Line 2: One sentence explaining why.")]
     (try
-      (let [response (call-api api-key prompt model)
-            lines (->> (str/split-lines response)
-                       (remove str/blank?))
-            verdict (str/trim (first lines))
-            explanation (str/trim (or (second lines) "No explanation provided."))]
-        {:function func-name
-         :intent intent
-         :verified? (= verdict "VERIFIED")
-         :explanation explanation})
+      (let [response (call-api api-key prompt model 256)]
+        (parse-verdict response func-name intent))
       (catch Exception e
-        {:function func-name
-         :intent intent
-         :verified? false
+        {:function func-name :intent intent :verified? false
          :explanation (str "Verification unavailable: " (.getMessage e))}))))
+
+;; ── Verification routing ─────────────────────────────────────
+
+(defn- verify-function
+  "Route to dynamic or static verification based on function signature.
+  Dynamic verification is used when the function has only primitive
+  params (or no params). Static is used for pointer/complex params."
+  [func module api-key model]
+  (if (all-primitive-params? func)
+    (dynamic-verify-function func module api-key model)
+    (static-verify-function func api-key model)))
 
 ;; ── Public API ───────────────────────────────────────────────
 
@@ -252,7 +445,7 @@
         :error "ANTHROPIC_API_KEY is not set. export ANTHROPIC_API_KEY='sk-ant-...'"}
        (let [funcs-with-intent (filter #(some? (extract-intent %))
                                        (:functions module))
-             results (mapv #(verify-function % api-key model) funcs-with-intent)
+             results (mapv #(verify-function % module api-key model) funcs-with-intent)
              all-ok? (every? :verified? results)]
          {:ok? all-ok?
           :results results})))))


### PR DESCRIPTION
Implements Layer 4 of the ARIA pipeline — runtime verification that each function's implementation matches its declared (intent ...) annotation.

## How it works

Verification is dynamic, not static. For each function with an intent annotation, the verifier generates a thin wrapper module, compiles it to C, runs it with concrete test inputs, captures the output, and asks the Claude API whether the observed behavior matches the declared intent. No IR reading. No manual tracing. Actual execution.

For functions with io effects and no params (like $main), the function is run directly and stdout is captured as the observed behavior.

For functions with complex params (pointers, structs), the verifier falls back to static code review.

## New flag

```
clojure -M:run <file.aria> --verify
```

Orthogonal to backend selection:

```
clojure -M:run <file.aria> --verify --backend jvm --emit-jar
clojure -M:run <file.aria> --verify --emit-c
```

Exits with code 1 if any function fails verification — CI-friendly. Graceful skip if ANTHROPIC_API_KEY is not set.

## What this found during development

During user testing the verifier correctly identified itself as unreliable on the first three prompt-based implementations. The switch to dynamic verification resolved all false negatives. fibonacci.aria passes 3/3. A deliberately misleading intent annotation (claiming to sort integers while printing hello world) correctly returns NOT_VERIFIED.

## Files

- src/aria/verifier.clj — new verification engine
- src/aria/main.clj — --verify flag, orthogonal to backend dispatch
- test/aria/verifier_test.clj — 9 tests, no live API calls

All 103 tests pass.

Requires ANTHROPIC_API_KEY and gcc at verification time. Neither is required for compilation — only for --verify.

Closes #6